### PR TITLE
Fix modman for "auto-append-gitignore"

### DIFF
--- a/modman
+++ b/modman
@@ -1,1 +1,1 @@
-app/code/community/Varien/Autoload.php  	app/code/community/Varien/
+app/code/community/Varien/Autoload.php  	app/code/community/Varien/Autoload.php


### PR DESCRIPTION
magento-hackathon/magento-composer-installer has an option
"auto-append-gitignore" which adds the contents of modman to .gitignore
for you . However, it does this blindly and using a wildcard on a
directory causes the entire directory to be added, in this case the
/app/code/community/Varien/ directory
